### PR TITLE
Fix Ember 6 compatibility issues: mobileView property and location se…

### DIFF
--- a/assets/javascripts/discourse/lib/DcsIFrame.js.es6
+++ b/assets/javascripts/discourse/lib/DcsIFrame.js.es6
@@ -478,16 +478,25 @@ export class DcsIFrame {
 
 		// Ember doesn't support anchors. So we need to manage them manually.
 		// https://github.com/discourse/discourse/blob/35bef72d4ed6d530468bdc091bc076d431a2cdc4/app/assets/javascripts/discourse/lib/discourse-location.js.es6#L85
-		const location = this.container.lookup('location:discourse-location')
-		if (hash !== location.location.hash) {
-			const url = hash || path // "hash" to set the hash, "path" to reset the hash
-			transition.then(() => {
-				if (mode === 'REPLACE' || transitionActuallyOccurred) {
-					location['replaceURL'](url)
-				} else {
-					location['setURL'](url)
-				}
-			})
+		try {
+			const location = this.container.lookup('location:discourse-location')
+			if (location && hash !== window.location.hash) {
+				const url = hash || path // "hash" to set the hash, "path" to reset the hash
+				transition.then(() => {
+					if (mode === 'REPLACE' || transitionActuallyOccurred) {
+						if (typeof location['replaceURL'] === 'function') {
+							location['replaceURL'](url)
+						}
+					} else {
+						if (typeof location['setURL'] === 'function') {
+							location['setURL'](url)
+						}
+					}
+				})
+			}
+		} catch (e) {
+			// Location service may not be available or structure may have changed
+			console.warn('Failed to handle location hash:', e)
 		}
 	}
 

--- a/assets/javascripts/discourse/lib/DcsLayout.js.es6
+++ b/assets/javascripts/discourse/lib/DcsLayout.js.es6
@@ -155,8 +155,9 @@ export class DcsLayout {
     if (this.saveMobileView === null) {
       this.saveMobileView = this.appCtrl.site.mobileView || false
     }
-    const forceMobileView = this.saveMobileView || layout === 2 || layout === 3
-    this.appCtrl.site.set('mobileView', forceMobileView)
+    // NOTE: In Discourse 3.6/Ember 6, mobileView is a getter-only property and cannot be set
+    // const forceMobileView = this.saveMobileView || layout === 2 || layout === 3
+    // this.appCtrl.site.set('mobileView', forceMobileView)
 
     this.prevLayout = layout
   }


### PR DESCRIPTION
…rvice

- DcsLayout.js: Remove attempt to set getter-only mobileView property in Ember 6

  mobileView is now read-only in Discourse 3.6+, so we just remove this code

- DcsIFrame.js: Fix location service access errors in _goToPathFromClient

  Added null checks and fallback to window.location.hash

  Wrapped in try-catch to handle service unavailability

- These were blocking layout updates and route navigation