### PR TITLE
Implement UI refinements: hide tags/categories, change sidebar color …

### DIFF
--- a/assets/javascripts/discourse/initializers/docuss.js.es6
+++ b/assets/javascripts/discourse/initializers/docuss.js.es6
@@ -161,6 +161,23 @@ export default {
                 routeName: currentRouteName,
                 queryParamsOnly,
               });
+              
+              // Hide Discourse sidebar when on Docuss map
+              const isSidebarService = container.lookup("service:sidebar");
+              if (isSidebarService && currentRouteName === "docuss.index") {
+                try {
+                  // For newer Discourse versions with sidebar service
+                  if (typeof isSidebarService.closeSidebar === 'function') {
+                    isSidebarService.closeSidebar();
+                    console.log("✓ Sidebar closed for docuss.index");
+                  } else if (isSidebarService.toggleSidebar && typeof isSidebarService.toggleSidebar === 'function') {
+                    // Some versions use toggleSidebar
+                    isSidebarService.toggleSidebar();
+                  }
+                } catch (e) {
+                  console.warn("Could not close sidebar:", e);
+                }
+              }
             } catch (e) {
               console.warn("onDidTransition failed:", e);
             }

--- a/assets/stylesheets/docuss.css
+++ b/assets/stylesheets/docuss.css
@@ -108,7 +108,7 @@ html.dcs2[dcs-layout='3']:not(.dcs-wide) #dcs-left {
 
 html.dcs2 #dcs-splitbar {
   flex: 0 0 23px;
-  background-color: rgb(0, 111, 81);
+  background-color: #2596be;
   flex-direction: column;
   cursor: pointer;
   display: none;
@@ -165,27 +165,33 @@ html.dcs2 #dcs-ghost .dcs-ghost-splitbar {
   left: 0;
   bottom: 0;
   width: 23px;
-  background-color: rgb(0, 111, 81);
+  background-color: #2596be;
 }
 
 /*******************************************************************************
 	Hide Docuss Tags
 *******************************************************************************/
 
-/* Hide dcs tags in tag filter dropdown */
+/* Hide all dcs tags in tag filter dropdown */
 html.dcs2:not(.dcs-debug) li[data-name^='dcs-'] {
   display: none;
 }
 
-/* Hide dcs tags in tag chooser */
+/* Hide all dcs tags in tag chooser */
 html.dcs2:not(.dcs-debug) .mini-tag-chooser > div[data-name^='dcs-'] > span,
 html.dcs2:not(.dcs-debug) .mini-tag-chooser .selected-tag[data-value^='dcs-'] {
   display: none;
 }
 
-/* Hide dcs tags everywhere else */
-/* NOTICE THAT IT DOESN'T WORK WELL IN THE TAGS PAGE */
+/* Hide all dcs tags everywhere else */
 html.dcs2:not(.dcs-debug) a.discourse-tag[data-tag-name^='dcs-'] {
+  display: none;
+}
+
+/* Hide all regular tags in topic list and pages */
+html.dcs2:not(.dcs-debug) .topic-tags,
+html.dcs2:not(.dcs-debug) .tags-container,
+html.dcs2:not(.dcs-debug) .tag-box {
   display: none;
 }
 
@@ -222,6 +228,11 @@ html.dcs2:not(.dcs-debug).dcs-disable-cats
   .navigation-container
   li[title='all topics grouped by category'] {
   display: none !important;
+}
+
+/* Hide category cells in topic list */
+html.dcs2:not(.dcs-debug).dcs-disable-cats td.category {
+  display: none;
 }
 
 /* Hide category links in topic list footer. This will cause ugly bugs. For 
@@ -444,5 +455,22 @@ html.dcs3 #dcs-left,
 html.dcs3 #dcs-right {
   flex: 1 0 0;
   overflow-y: auto; /* Allow for a vertical scrollbar */
+  display: none;
+}
+
+/*******************************************************************************
+	Hide new Discourse sidebar in footer
+*******************************************************************************/
+
+/* Hide the new Discourse 3.6+ sidebar that appears at the bottom */
+html.dcs2 .sidebar-wrapper {
+  display: none;
+}
+
+html.dcs2 .sidebar-toggle-button {
+  display: none;
+}
+
+html.dcs2 footer.topic-list-bottom .sidebar-footer-toggle {
   display: none;
 }


### PR DESCRIPTION
…to #2596be, and hide Discourse sidebar

- Hide all regular tags in topic list and tag pages by default (shown only in debug mode with Alt+A)
- Hide all dcs- prefixed tags in tag dropdowns and tag chooser
- Hide category cells in topic list view
- Change Docuss sidebar (split bar) color from green (rgb(0, 111, 81)) to blue (#2596be)
- Apply color change to both active and ghost split bars
- Hide new Discourse 3.6+ sidebar footer and toggle button when Docuss is active
- Close sidebar via sidebar service when navigating to docuss.index route
- Added sidebar close logic with fallback for different Discourse versions