### PR TITLE
Fix tag/category hiding and composer auto-close issue

### DIFF
--- a/assets/javascripts/discourse/initializers/docuss.js.es6
+++ b/assets/javascripts/discourse/initializers/docuss.js.es6
@@ -193,9 +193,13 @@ export default {
           if (shrinkComposer) {
             try {
               const composerCtrl = container.lookup("controller:composer");
-              // Check if composer exists AND has a model before trying to shrink
+              // Check if composer exists AND has a model AND is actually OPEN before trying to shrink
               if (composerCtrl?.model && composerCtrl?.shrink) {
-                composerCtrl.shrink();
+                const composeState = composerCtrl.model.composeState || composerCtrl.model.get?.("composeState");
+                // Only shrink if composer is not open or is already minimized
+                if (composeState !== Composer.OPEN) {
+                  composerCtrl.shrink();
+                }
               }
             } catch (e) {
               // Don't log this error - it's expected when composer doesn't exist

--- a/assets/stylesheets/docuss.css
+++ b/assets/stylesheets/docuss.css
@@ -173,26 +173,49 @@ html.dcs2 #dcs-ghost .dcs-ghost-splitbar {
 *******************************************************************************/
 
 /* Hide all dcs tags in tag filter dropdown */
-html.dcs2:not(.dcs-debug) li[data-name^='dcs-'] {
+html.dcs2 li[data-name^='dcs-'] {
   display: none;
+}
+
+/* Show dcs tags when in debug mode */
+html.dcs2.dcs-debug li[data-name^='dcs-'] {
+  display: block;
 }
 
 /* Hide all dcs tags in tag chooser */
-html.dcs2:not(.dcs-debug) .mini-tag-chooser > div[data-name^='dcs-'] > span,
-html.dcs2:not(.dcs-debug) .mini-tag-chooser .selected-tag[data-value^='dcs-'] {
+html.dcs2 .mini-tag-chooser > div[data-name^='dcs-'] > span,
+html.dcs2 .mini-tag-chooser .selected-tag[data-value^='dcs-'] {
   display: none;
+}
+
+/* Show dcs tags in tag chooser when in debug mode */
+html.dcs2.dcs-debug .mini-tag-chooser > div[data-name^='dcs-'] > span,
+html.dcs2.dcs-debug .mini-tag-chooser .selected-tag[data-value^='dcs-'] {
+  display: inline;
 }
 
 /* Hide all dcs tags everywhere else */
-html.dcs2:not(.dcs-debug) a.discourse-tag[data-tag-name^='dcs-'] {
+html.dcs2 a.discourse-tag[data-tag-name^='dcs-'] {
   display: none;
 }
 
+/* Show dcs tags everywhere else when in debug mode */
+html.dcs2.dcs-debug a.discourse-tag[data-tag-name^='dcs-'] {
+  display: inline-block;
+}
+
 /* Hide all regular tags in topic list and pages */
-html.dcs2:not(.dcs-debug) .topic-tags,
-html.dcs2:not(.dcs-debug) .tags-container,
-html.dcs2:not(.dcs-debug) .tag-box {
+html.dcs2 .topic-tags,
+html.dcs2 .tags-container,
+html.dcs2 .tag-box {
   display: none;
+}
+
+/* Show all regular tags when in debug mode */
+html.dcs2.dcs-debug .topic-tags,
+html.dcs2.dcs-debug .tags-container,
+html.dcs2.dcs-debug .tag-box {
+  display: block;
 }
 
 /*******************************************************************************
@@ -206,7 +229,7 @@ html.dcs2:not(.dcs-debug) .tag-box {
 Don't use visibility:hidden here, or it will  hide borders also. In admin mode,
 where there are categories (Staff, Lounge), this would create a hole in 
 the table's header */
-html.dcs2:not(.dcs-debug).dcs-disable-cats th.category {
+html.dcs2.dcs-disable-cats th.category {
   /* The following line is better than opacity:0, because it reduces the column
 	width. Beware: the !important is important for the tag topic list */
   font-size: 0pt !important;
@@ -214,24 +237,24 @@ html.dcs2:not(.dcs-debug).dcs-disable-cats th.category {
   cursor: default;
 }
 
-html.dcs2:not(.dcs-debug).dcs-disable-cats a.badge-category,
-html.dcs2:not(.dcs-debug).dcs-disable-cats ul.category-links,
-html.dcs2:not(.dcs-debug).dcs-disable-cats ul.category-links + hr,
-html.dcs2:not(.dcs-debug).dcs-disable-cats div.category-input,
-html.dcs2:not(.dcs-debug).dcs-disable-cats body:not(.admin-interface) div.category-chooser,
-html.dcs2:not(.dcs-debug).dcs-disable-cats ul#category-filter li:last-of-type,
-html.dcs2:not(.dcs-debug).dcs-disable-cats
+html.dcs2.dcs-disable-cats a.badge-category,
+html.dcs2.dcs-disable-cats ul.category-links,
+html.dcs2.dcs-disable-cats ul.category-links + hr,
+html.dcs2.dcs-disable-cats div.category-input,
+html.dcs2.dcs-disable-cats body:not(.admin-interface) div.category-chooser,
+html.dcs2.dcs-disable-cats ul#category-filter li:last-of-type,
+html.dcs2.dcs-disable-cats
   .navigation-container
   .category-breadcrumb
   > li:first-child,
-html.dcs2:not(.dcs-debug).dcs-disable-cats
+html.dcs2.dcs-disable-cats
   .navigation-container
   li[title='all topics grouped by category'] {
   display: none !important;
 }
 
 /* Hide category cells in topic list */
-html.dcs2:not(.dcs-debug).dcs-disable-cats td.category {
+html.dcs2.dcs-disable-cats td.category {
   display: none;
 }
 
@@ -239,7 +262,7 @@ html.dcs2:not(.dcs-debug).dcs-disable-cats td.category {
 example, "There are no more unread topics. Browse all categories or view latest 
 topics" will be turned into
 */
-html.dcs2:not(.dcs-debug).dcs-disable-cats
+html.dcs2.dcs-disable-cats
   footer.topic-list-bottom
   a[href='/categories'] {
   display: none;
@@ -249,7 +272,7 @@ html.dcs2:not(.dcs-debug).dcs-disable-cats
 required, cause the fact that we disabled categories and tags had removed
 input fields and now the text preview is too much toward the top
 */
-html.dcs2:not(.dcs-debug).dcs-disable-cats .d-editor-preview-wrapper {
+html.dcs2.dcs-disable-cats .d-editor-preview-wrapper {
   margin-top: 0px !important;
 }
 


### PR DESCRIPTION
Tag and Category Hiding Fixes:
- Removed :not(.dcs-debug) pseudo-class from CSS selectors
- Changed from negative logic (hide unless in debug) to positive logic (hide by default, show when debug)
- Tags now properly hidden in topic lists, tag pages, dropdowns, and tag chooser by default
- Tags show with Alt+A debug toggle for admins
- Categories now properly hidden when dcs-disable-cats class is applied
- Both features now work regardless of debug mode

Composer Auto-Close Fix:
- Fixed issue where composer was closing and saving as draft when creating new thread after clicking link
- Added check to prevent shrinking composer when it's currently OPEN
- Only shrink composer when it's minimized or closed
- This prevents the automatic close that was happening after navigation with a DcsTag