### PR TITLE
Fix category/tag toggle and revert button styling

### DIFF
--- a/assets/javascripts/discourse/initializers/docuss.js.es6
+++ b/assets/javascripts/discourse/initializers/docuss.js.es6
@@ -347,34 +347,8 @@ export default {
         });
       });
 
-      // ========================================
-      // Alt+A Toggle for Category/Tags (Admin only)
-      // ========================================
-      schedule("afterRender", () => {
-        try {
-          document.addEventListener("keydown", (ev) => {
-            if (ev.altKey && ev.key?.toLowerCase() === "a") {
-              try {
-                const categorySelect = document.querySelector(".category-chooser, .select-kit");
-                const tagBoxes = document.querySelectorAll(".tag-chooser, .tag-row, .tag-box");
-                
-                if (categorySelect) {
-                  categorySelect.style.display = 
-                    (categorySelect.style.display === "none") ? "" : "none";
-                }
-                
-                tagBoxes.forEach((tb) => {
-                  tb.style.display = (tb.style.display === "none") ? "" : "none";
-                });
-              } catch (e) {
-                console.warn("Alt+A toggle failed:", e);
-              }
-            }
-          });
-        } catch (e) {
-          console.error("Failed to attach Alt+A listener:", e);
-        }
-      });
+      // Alt+A toggle is already handled in onAfterRender.js
+      // It toggles the dcs-debug class which controls tag/category visibility via CSS
     });
   },
 };

--- a/assets/stylesheets/docuss.css
+++ b/assets/stylesheets/docuss.css
@@ -516,34 +516,3 @@ html.dcs2 .sidebar-toggle-button {
 html.dcs2 footer.topic-list-bottom .sidebar-footer-toggle {
   display: none;
 }
-
-/*******************************************************************************
-	Style Navigation Links as Buttons (Tasks, Media, Stories)
-*******************************************************************************/
-
-/* Target navigation links in the iframe and style as buttons */
-#dcs-left a {
-  /* Make them 3x bigger */
-  font-size: 1.3rem;
-  padding: 0.75rem 1.5rem;
-  display: inline-block;
-  margin: 0.5rem;
-  
-  /* Match Edit button styling */
-  background-color: #0088cc;
-  color: #ffffff;
-  border-radius: 4px;
-  border: 1px solid #0077b3;
-  text-decoration: none;
-  font-weight: 500;
-  transition: background-color 0.2s ease;
-  cursor: pointer;
-}
-
-#dcs-left a:hover {
-  background-color: #0077b3;
-}
-
-#dcs-left a:active {
-  background-color: #006699;
-}


### PR DESCRIPTION
Fixes:
- Removed duplicate Alt+A handler from initializer
- Alt+A toggle now uses onAfterRender.js implementation which properly toggles .dcs-debug class
- This ensures category and tag hiding/showing works consistently via CSS rules
- Categories now properly respond to Alt+A toggle just like tags in list view

Revert:
- Removed navigation link button styling CSS (will be implemented on React side)
- Removed #dcs-left a selector styling rules