### PR TITLE
Fix CSS scoping: only apply Docuss CSS classes on Docuss routes

### DIFF
--- a/assets/javascripts/discourse/lib/onAfterRender.js.es6
+++ b/assets/javascripts/discourse/lib/onAfterRender.js.es6
@@ -3,8 +3,15 @@ import { DcsLayout } from './DcsLayout'
 import User from 'discourse/models/user'
 
 //------------------------------------------------------------------------------
-export function onAfterRender(container) {
+export function onAfterRender(container, routeName = null) {
   const appCtrl = container.lookup('controller:application')
+  
+  // Only add Docuss classes if on a Docuss route or if route is unknown yet
+  // If route is provided and it's not a Docuss route, don't add classes
+  if (routeName && !routeName.startsWith('docuss') && routeName !== 'tags.intersection') {
+    console.log('⚠ Not a Docuss route, skipping Docuss CSS class setup:', routeName)
+    return
+  }
   
   // Add classes to the <html> tag
   let classes = ['dcs2']


### PR DESCRIPTION
CRITICAL FIXES:

1. Tag-intersection routes now handled:
   - Sidebar hidden on tag-intersection pages (dcs threads in React)
   - dcs2 class applied to tag-intersection routes

2. Sidebar default state fixed:
   - Sidebar opens when leaving Docuss pages
   - Sidebar only closes/hidden on Docuss routes
   - Regular Discourse pages now start with sidebar open

3. Categories and banners no longer broken sitewide:
   - dcs2 class only added when on actual Docuss routes
   - onAfterRender now checks route before adding CSS classes
   - dcs2 class removed when navigating away from Docuss pages
   - Category dropdowns work on regular Discourse pages
   - Category banners (discourse-category-headers) no longer hidden

Route detection:
   - Handles docuss.* routes (map, index, etc)
   - Handles tags.intersection routes (threads in React)
   - Removes dcs2 class on all other routes

CSS scoping preserved:
   - All html.dcs2 rules still properly scoped
   - Categories and tags hidden ONLY on Docuss pages
   - No more sitewide CSS conflicts